### PR TITLE
volume export: refuse to write to terminal (TTY)

### DIFF
--- a/cmd/podman/volumes/export.go
+++ b/cmd/podman/volumes/export.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/podman/v5/cmd/podman/registry"
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -48,8 +49,13 @@ func export(cmd *cobra.Command, args []string) error {
 	containerEngine := registry.ContainerEngine()
 	ctx := context.Background()
 
-	if targetPath == "" && cmd.Flag("output").Changed {
-		return errors.New("must provide valid path for file to write to")
+	if targetPath == "" {
+		if cmd.Flag("output").Changed {
+			return errors.New("must provide valid path for file to write to")
+		}
+		if term.IsTerminal(int(os.Stdout.Fd())) {
+			return errors.New("refusing to export to terminal. Use -o flag or redirect")
+		}
 	}
 
 	exportOpts := entities.VolumeExportOptions{}

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -616,4 +616,32 @@ EOF
     run_podman volume rm $volume_name --force
 }
 
+@test "podman volume export test in TTY" {
+
+    run_podman volume create testVol
+    run_podman run -v testVol:/data --rm $IMAGE sh -c "echo hello > /data/myfile"
+
+    # Positive Case
+    tarfile=${PODMAN_TMPDIR}/hello$(random_string | tr A-Z a-z).tar
+
+    # `script` command opened a new pesudo-terminal(PTY) to make podman think
+    # it's running in a terminal.
+    all_outputs=$(script -q -c "$PODMAN volume export testVol --output=$tarfile; echo \$?" /dev/null)
+    exit_code=$(echo "$all_outputs" | sed -n '1p' | tr -d '\n\r')
+
+    is "$exit_code" "0" "Exit code should be 0"
+
+    rm -f $tarfile
+
+    # Negative Case
+    all_outputs=$(script -q -c "$PODMAN volume export testVol; echo \$?" /dev/null)
+    output=$(echo "$all_outputs" | sed -n '1p' | tr -d '\n\r')
+    exit_code=$(echo "$all_outputs" | sed -n '2p' | tr -d '\n\r')
+
+    is "$exit_code" "125" "Exit code should be 125"
+    is "$output" "Error: refusing to export to terminal. Use -o flag or redirect" "Should refuse to export to terminal"
+
+    run_podman volume rm testVol --force
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Prevent `podman volume export` from showing raw tar contents directly to the terminal (STDOUT). If not redirected and without output flag, error message is expected.


<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests).

Finally, be sure to sign commits with your real name. Since by opening
a PR you already have commits, you can add signatures if needed with
something like `git commit -s --amend`.
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
